### PR TITLE
Public computeUrl method in cloudinary service

### DIFF
--- a/addon/helpers/cloudinary-url.js
+++ b/addon/helpers/cloudinary-url.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-const { computed, inject, typeOf } = Ember;
+const { inject, typeOf } = Ember;
 
 
 export default Ember.Helper.extend({
@@ -22,6 +22,6 @@ export default Ember.Helper.extend({
    * @return {String}                               URL for image
    */
   compute(publicId, hash) {
-    return this.get('cloudinary').computeUrl([publicId], hash) ;
+    return this.get('cloudinary').getURL([publicId], hash) ;
   }
 });

--- a/addon/helpers/cloudinary-url.js
+++ b/addon/helpers/cloudinary-url.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-const { inject, typeOf } = Ember;
+const { inject } = Ember;
 
 
 export default Ember.Helper.extend({

--- a/addon/helpers/cloudinary-url.js
+++ b/addon/helpers/cloudinary-url.js
@@ -5,17 +5,6 @@ const { computed, inject, typeOf } = Ember;
 export default Ember.Helper.extend({
   cloudinary: inject.service(),
 
-  /** @property {String[]} concatenatedTransforms */
-  concatenatedTransforms: computed('cloudinary.config.CONCATENATED_TRANSFORMS', function() {
-    // Protection from Strings
-    const concatenatedTransforms = this.get('cloudinary.config.CONCATENATED_TRANSFORMS') || [];
-    return Array.isArray(concatenatedTransforms) ? concatenatedTransforms : [concatenatedTransforms];
-  }),
-  /** @property {String[]} defaultTransforms */
-  defaultTransforms: computed.readOnly('cloudinary.config.DEFAULT_TRANSFORMS'),
-  /** @property {String} defaultImageFormat */
-  defaultImageFormat: computed.readOnly('cloudinary.config.DEFAULT_IMAGE_FORMAT'),
-
   /**
    * @method compute
    * @param  {String}          [publicId]           Public id of image in Cloudinary
@@ -32,69 +21,8 @@ export default Ember.Helper.extend({
    * @param  {String[]}        hash.transforms
    * @return {String}                               URL for image
    */
-  compute([publicId] = [], hash = {}) {
-    /** @validation */
-    if (!publicId) {
-      return '';
-    }
-
-    let {
-      cloudName,
-      width,
-      height,
-      version,
-      domain,
-      subDomain,
-      cdnDistribution,
-      secure,
-      resourceType,
-      type,
-      format,
-      transforms
-    } = hash;
-    // Default params
-    if (typeOf(resourceType) === 'undefined') { resourceType = 'image'; }
-    if (typeOf(type) === 'undefined') { type = 'upload'; }
-    if (typeOf(format) === 'undefined') { format = this.get('defaultImageFormat'); }
-    if (typeOf(transforms) === 'undefined') { transforms = this.get('defaultTransforms'); }
-
-
-    /** @type {String[]} Transforms to concatenate */
-    const concatenatedTransforms = this.get('concatenatedTransforms');
-    /** Convert transforms to array if the given param was string **/
-    transforms = Array.isArray(transforms) ? transforms : transforms || [];
-    /** Adds concatenated transforms **/
-    transforms = concatenatedTransforms.concat(transforms);
-    /** Adds width if exists **/
-    transforms = width || width === 0 ? [`w_${width}`].concat(transforms) : transforms;
-    /** Adds height if exists **/
-    transforms = height || height === 0 ? [`h_${height}`].concat(transforms) : transforms;
-
-    /** Encoding */
-    publicId = encodeURIComponent(decodeURIComponent(publicId)).replace(/%3A/g, ":").replace(/%2F/g, "/");
-    /** Add format if exists */
-    publicId = format ? `${publicId}.${format}` : publicId;
-
-    /** @type {Ember.Service} */
-    const cloudinary = this.get('cloudinary');
-    /** @type {String} */
-    const urlPrefix = cloudinary.publicIdURLPrefix(publicId, {
-      cloudName,
-      subDomain,
-      domain,
-      cdnDistribution,
-      secure
-    });
-
-    /** @type {String} Transforms in String form */
-    const sTransforms = transforms.join(',');
-
-    return (
-      urlPrefix + '/' +
-      `${resourceType}/${type}/` +
-      (sTransforms ? sTransforms + '/' : '') +
-      (version ? `v${version}/` : '') +
-      publicId
-    );
+  compute() {
+    console.log(JSON.stringify(arguments, null, 2)) ;
+    return this.get('cloudinary').cloudinaryUrl(arguments) ;
   }
 });

--- a/addon/helpers/cloudinary-url.js
+++ b/addon/helpers/cloudinary-url.js
@@ -23,6 +23,6 @@ export default Ember.Helper.extend({
    */
   compute() {
     console.log(JSON.stringify(arguments, null, 2)) ;
-    return this.get('cloudinary').cloudinaryUrl(arguments) ;
+    return this.get('cloudinary').computeUrl(arguments) ;
   }
 });

--- a/addon/helpers/cloudinary-url.js
+++ b/addon/helpers/cloudinary-url.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-const { inject } = Ember;
+const { inject, isEmpty } = Ember;
 
 
 export default Ember.Helper.extend({

--- a/addon/helpers/cloudinary-url.js
+++ b/addon/helpers/cloudinary-url.js
@@ -22,6 +22,6 @@ export default Ember.Helper.extend({
    * @return {String}                               URL for image
    */
   compute(publicId, hash) {
-    return this.get('cloudinary').computeUrl(publicId, hash) ;
+    return this.get('cloudinary').computeUrl([publicId], hash) ;
   }
 });

--- a/addon/helpers/cloudinary-url.js
+++ b/addon/helpers/cloudinary-url.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-const { inject, isEmpty } = Ember;
+const { inject } = Ember;
 
 
 export default Ember.Helper.extend({
@@ -23,7 +23,8 @@ export default Ember.Helper.extend({
    */
   compute(publicId, hash) {
     /** @validation */
-    if ( isEmpty(publicId) ) {
+    if ( isEmpty(publicId) ||
+        (Array.isArray(publicId) && publicId.length === 1 && !publicId[0]) {
       return '';
     }
     return this.get('cloudinary').getURL([publicId], hash) ;

--- a/addon/helpers/cloudinary-url.js
+++ b/addon/helpers/cloudinary-url.js
@@ -24,7 +24,8 @@ export default Ember.Helper.extend({
   compute(publicId, hash) {
     /** @validation */
     if ( isEmpty(publicId) ||
-        (Array.isArray(publicId) && publicId.length === 1 && !publicId[0]) {
+        (Array.isArray(publicId) && publicId.length === 1 && !publicId[0])
+    ) {
       return '';
     }
     return this.get('cloudinary').getURL([publicId], hash) ;

--- a/addon/helpers/cloudinary-url.js
+++ b/addon/helpers/cloudinary-url.js
@@ -22,6 +22,6 @@ export default Ember.Helper.extend({
    * @return {String}                               URL for image
    */
   compute(publicId, hash) {
-    return this.get('cloudinary').getURL([publicId], hash) ;
+    return this.get('cloudinary').getURL(publicId ? [publicId] : [], hash) ;
   }
 });

--- a/addon/helpers/cloudinary-url.js
+++ b/addon/helpers/cloudinary-url.js
@@ -21,8 +21,7 @@ export default Ember.Helper.extend({
    * @param  {String[]}        hash.transforms
    * @return {String}                               URL for image
    */
-  compute() {
-    console.log(JSON.stringify(arguments, null, 2)) ;
-    return this.get('cloudinary').computeUrl(arguments) ;
+  compute(publicId, hash) {
+    return this.get('cloudinary').computeUrl(publicId, hash) ;
   }
 });

--- a/addon/helpers/cloudinary-url.js
+++ b/addon/helpers/cloudinary-url.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-const { inject, isEmpty } = Ember;
+const { inject } = Ember;
 
 
 export default Ember.Helper.extend({
@@ -19,15 +19,13 @@ export default Ember.Helper.extend({
    * @param  {Boolean}         hash.secure
    * @param  {String}          hash.type
    * @param  {String[]}        hash.transforms
-   * @return {String}                               URL for image
+   * @return {String}          URL for image
    */
-  compute(publicId, hash) {
+  compute([publicId] = [], hash = {}) {
     /** @validation */
-    if ( isEmpty(publicId) ||
-        (Array.isArray(publicId) && publicId.length === 1 && !publicId[0])
-    ) {
-      return '';
+    if ( !publicId ) {
+      return '' ;
     }
-    return this.get('cloudinary').getURL([publicId], hash) ;
+    return this.get('cloudinary').getURL(publicId, hash) ;
   }
 });

--- a/addon/helpers/cloudinary-url.js
+++ b/addon/helpers/cloudinary-url.js
@@ -22,6 +22,10 @@ export default Ember.Helper.extend({
    * @return {String}                               URL for image
    */
   compute(publicId, hash) {
-    return this.get('cloudinary').getURL(publicId ? [publicId] : [], hash) ;
+    /** @validation */
+    if ( isEmpty(publicId) ) {
+      return '';
+    }
+    return this.get('cloudinary').getURL([publicId], hash) ;
   }
 });

--- a/addon/services/cloudinary.js
+++ b/addon/services/cloudinary.js
@@ -196,7 +196,7 @@ export default Ember.Service.extend({
   defaultImageFormat: computed.readOnly('config.DEFAULT_IMAGE_FORMAT'),
 
   /**
-   * @method cloudinaryUrl
+   * @method computeUrl
    * @param  {String}          [publicId]           Public id of image in Cloudinary
    * @param  {String}          hash.format          File extension)
    * @param  {String}          hash.cloudName
@@ -211,7 +211,7 @@ export default Ember.Service.extend({
    * @param  {String[]}        hash.transforms
    * @return {String}                               URL for image
    */
-  cloudinaryUrl([publicId] = [], hash = {}) {
+  computeUrl([publicId] = [], hash = {}) {
     /** @validation */
     if (!publicId) {
       return '';

--- a/addon/services/cloudinary.js
+++ b/addon/services/cloudinary.js
@@ -211,7 +211,7 @@ export default Ember.Service.extend({
    * @param  {String[]}        hash.transforms
    * @return {String}                               URL for image
    */
-  computeUrl([publicId] = [], hash = {}) {
+  computeUrl(publicId = [], hash = {}) {
     /** @validation */
     if (!publicId) {
       return '';

--- a/addon/services/cloudinary.js
+++ b/addon/services/cloudinary.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-const { computed, Logger, typeOf } = Ember;
+const { computed, Logger, typeOf, isEmpty } = Ember;
 
 /** @const {String} Default fallback domain */
 export const CLOUDINARY_DOMAIN = 'cloudinary.com';
@@ -184,19 +184,15 @@ export default Ember.Service.extend({
   },
 
 
-  /** @property {String[]} concatenatedTransforms */
-  concatenatedTransforms: computed('config.CONCATENATED_TRANSFORMS', function() {
+  /** @property {String[]} _concatenatedTransforms */
+  _concatenatedTransforms: computed('config.CONCATENATED_TRANSFORMS', function() {
     // Protection from Strings
     const concatenatedTransforms = this.get('config.CONCATENATED_TRANSFORMS') || [];
     return Array.isArray(concatenatedTransforms) ? concatenatedTransforms : [concatenatedTransforms];
   }),
-  /** @property {String[]} defaultTransforms */
-  defaultTransforms: computed.readOnly('config.DEFAULT_TRANSFORMS'),
-  /** @property {String} defaultImageFormat */
-  defaultImageFormat: computed.readOnly('config.DEFAULT_IMAGE_FORMAT'),
 
   /**
-   * @method computeUrl
+   * @method getURL
    * @param  {String}          [publicId]           Public id of image in Cloudinary
    * @param  {String}          hash.format          File extension)
    * @param  {String}          hash.cloudName
@@ -211,9 +207,9 @@ export default Ember.Service.extend({
    * @param  {String[]}        hash.transforms
    * @return {String}                               URL for image
    */
-  computeUrl(publicId = [], hash = {}) {
+  getURL(publicId = [], hash = {}) {
     /** @validation */
-    if (!publicId) {
+    if ( isEmpty(publicId) ) {
       return '';
     }
 
@@ -234,12 +230,11 @@ export default Ember.Service.extend({
     // Default params
     if (typeOf(resourceType) === 'undefined') { resourceType = 'image'; }
     if (typeOf(type) === 'undefined') { type = 'upload'; }
-    if (typeOf(format) === 'undefined') { format = this.get('defaultImageFormat'); }
-    if (typeOf(transforms) === 'undefined') { transforms = this.get('defaultTransforms'); }
-
+    if (typeOf(format) === 'undefined') { format = this.get('config.DEFAULT_IMAGE_FORMAT'); }
+    if (typeOf(transforms) === 'undefined') { transforms = this.get('DEFAULT_TRANSFORMS'); }
 
     /** @type {String[]} Transforms to concatenate */
-    const concatenatedTransforms = this.get('concatenatedTransforms');
+    const concatenatedTransforms = this.get('_concatenatedTransforms');
     /** Convert transforms to array if the given param was string **/
     transforms = Array.isArray(transforms) ? transforms : transforms || [];
     /** Adds concatenated transforms **/

--- a/addon/services/cloudinary.js
+++ b/addon/services/cloudinary.js
@@ -181,5 +181,97 @@ export default Ember.Service.extend({
     }
 
     return `${protocol}${subDomain}.${domain}${pathname}`;
+  },
+
+
+  /** @property {String[]} concatenatedTransforms */
+  concatenatedTransforms: computed('config.CONCATENATED_TRANSFORMS', function() {
+    // Protection from Strings
+    const concatenatedTransforms = this.get('config.CONCATENATED_TRANSFORMS') || [];
+    return Array.isArray(concatenatedTransforms) ? concatenatedTransforms : [concatenatedTransforms];
+  }),
+  /** @property {String[]} defaultTransforms */
+  defaultTransforms: computed.readOnly('config.DEFAULT_TRANSFORMS'),
+  /** @property {String} defaultImageFormat */
+  defaultImageFormat: computed.readOnly('config.DEFAULT_IMAGE_FORMAT'),
+
+  /**
+   * @method cloudinaryUrl
+   * @param  {String}          [publicId]           Public id of image in Cloudinary
+   * @param  {String}          hash.format          File extension)
+   * @param  {String}          hash.cloudName
+   * @param  {(String|Number)} hash.width
+   * @param  {(String|Number)} hash.height
+   * @param  {(String|Number)} hash.version
+   * @param  {String}          hash.domain
+   * @param  {String}          hash.subDomain
+   * @param  {Boolean}         hash.cdnDistribution
+   * @param  {Boolean}         hash.secure
+   * @param  {String}          hash.type
+   * @param  {String[]}        hash.transforms
+   * @return {String}                               URL for image
+   */
+  cloudinaryUrl([publicId] = [], hash = {}) {
+    /** @validation */
+    if (!publicId) {
+      return '';
+    }
+
+    let {
+      cloudName,
+      width,
+      height,
+      version,
+      domain,
+      subDomain,
+      cdnDistribution,
+      secure,
+      resourceType,
+      type,
+      format,
+      transforms
+    } = hash;
+    // Default params
+    if (typeOf(resourceType) === 'undefined') { resourceType = 'image'; }
+    if (typeOf(type) === 'undefined') { type = 'upload'; }
+    if (typeOf(format) === 'undefined') { format = this.get('defaultImageFormat'); }
+    if (typeOf(transforms) === 'undefined') { transforms = this.get('defaultTransforms'); }
+
+
+    /** @type {String[]} Transforms to concatenate */
+    const concatenatedTransforms = this.get('concatenatedTransforms');
+    /** Convert transforms to array if the given param was string **/
+    transforms = Array.isArray(transforms) ? transforms : transforms || [];
+    /** Adds concatenated transforms **/
+    transforms = concatenatedTransforms.concat(transforms);
+    /** Adds width if exists **/
+    transforms = width || width === 0 ? [`w_${width}`].concat(transforms) : transforms;
+    /** Adds height if exists **/
+    transforms = height || height === 0 ? [`h_${height}`].concat(transforms) : transforms;
+
+    /** Encoding */
+    publicId = encodeURIComponent(decodeURIComponent(publicId)).replace(/%3A/g, ":").replace(/%2F/g, "/");
+    /** Add format if exists */
+    publicId = format ? `${publicId}.${format}` : publicId;
+
+    /** @type {String} */
+    const urlPrefix = this.publicIdURLPrefix(publicId, {
+      cloudName,
+      subDomain,
+      domain,
+      cdnDistribution,
+      secure
+    });
+
+    /** @type {String} Transforms in String form */
+    const sTransforms = transforms.join(',');
+
+    return (
+      urlPrefix + '/' +
+      `${resourceType}/${type}/` +
+      (sTransforms ? sTransforms + '/' : '') +
+      (version ? `v${version}/` : '') +
+      publicId
+    );
   }
 });

--- a/addon/services/cloudinary.js
+++ b/addon/services/cloudinary.js
@@ -231,7 +231,7 @@ export default Ember.Service.extend({
     if (typeOf(resourceType) === 'undefined') { resourceType = 'image'; }
     if (typeOf(type) === 'undefined') { type = 'upload'; }
     if (typeOf(format) === 'undefined') { format = this.get('config.DEFAULT_IMAGE_FORMAT'); }
-    if (typeOf(transforms) === 'undefined') { transforms = this.get('DEFAULT_TRANSFORMS'); }
+    if (typeOf(transforms) === 'undefined') { transforms = this.get('config.DEFAULT_TRANSFORMS'); }
 
     /** @type {String[]} Transforms to concatenate */
     const concatenatedTransforms = this.get('_concatenatedTransforms');

--- a/addon/services/cloudinary.js
+++ b/addon/services/cloudinary.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-const { computed, Logger, typeOf, isEmpty } = Ember;
+const { computed, Logger, typeOf } = Ember;
 
 /** @const {String} Default fallback domain */
 export const CLOUDINARY_DOMAIN = 'cloudinary.com';
@@ -193,7 +193,7 @@ export default Ember.Service.extend({
 
   /**
    * @method getURL
-   * @param  {String}          [publicId]           Public id of image in Cloudinary
+   * @param  {String}          publicId           Public id of image in Cloudinary
    * @param  {String}          hash.format          File extension)
    * @param  {String}          hash.cloudName
    * @param  {(String|Number)} hash.width
@@ -207,9 +207,9 @@ export default Ember.Service.extend({
    * @param  {String[]}        hash.transforms
    * @return {String}                               URL for image
    */
-  getURL(publicId = [], hash = {}) {
+  getURL(publicId, hash = {}) {
     /** @validation */
-    if ( isEmpty(publicId) ) {
+    if ( !publicId ) {
       return '';
     }
 


### PR DESCRIPTION
This commit proposes a solution to security leaks caused by
some attribute bindings in ember 2.0+.
# Use case

Applying a cloudinary _background_-image to an element.
## Before

Template:

```hbs
<div style="background-image: url('{{cloudinary-url ...}}');">
</div>
```

Generates a [security warning](http://emberjs.com/deprecations/v1.x/#toc_binding-style-attributes) from Ember 1.13.
## After

Controller:

```js
import Ember from 'ember' ;
const { inject, computed, String, Controller } = Ember ;

export default Controller.extend({
  cloudinary: inject.service(),
  backgroundCSS: computed( function () {
    const cloudinary = this.get('cloudinary') ;
    var css = "background-image: url('" + cloudinary.computeUrl(...) + "');" ;
    return String.htmlSafe(css) ;
  })
}) ;
```

Template:

```hbs
<div style={{backgroundCSS}}>
</div>
```

Is safe and Ember 2.0 compatible.

**NOTE:**  

The `{{cloudinary-url ...}}` helper is still available to use with classic
`<img>` elements in templates.
